### PR TITLE
Dropdown -> Select + tuning, other small correctins

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
       {
         singleQuote: true,
         tabWidth: 2,
-        printWidth: 120,
+        printWidth: 100,
         trailingComma: 'all',
       },
     ],

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2019-02-09
+- Rename Dropdown to Select
+- Correct Select API
+- Fix small bugs
+
 ## [0.4.1] - 2019-02-08
 - Fixed popup's triangle from Tip component
 

--- a/index.js
+++ b/index.js
@@ -1,19 +1,25 @@
 import Button from './src/Button.vue';
 import Checkbox from './src/Checkbox.vue';
-import Dropdown from './src/Dropdown.vue';
+import LangButton from './src/LangButton.vue';
 import LangsBar from './src/LangsBar.vue';
+import Select from './src/Select.vue';
 import SwitchBox from './src/SwitchBox.vue';
+import TagBox from './src/TagBox.vue';
 import TagInput from './src/TagInput.vue';
+import TagList from './src/TagList.vue';
 import TextField from './src/TextField.vue';
 import Tip from './src/Tip.vue';
 
 export {
   Button,
   Checkbox,
-  Dropdown,
   LangsBar,
+  LangButton,
+  Select,
   SwitchBox,
+  TagBox,
   TagInput,
+  TagList,
   TextField,
   Tip,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protocol-one/ui-kit",
-  "version": "0.4.1",
+  "version": "1.0.0",
   "scripts": {
     "lint": "vue-cli-service lint"
   },

--- a/src/Button.vue
+++ b/src/Button.vue
@@ -5,6 +5,7 @@
   @click="emitClick"
 >
   {{ text }}
+  <slot/>
 </button>
 </template>
 

--- a/src/LangButton.vue
+++ b/src/LangButton.vue
@@ -1,6 +1,7 @@
 <template>
 <button :class="buttonClasses">
-  {{ text.toUpperCase() }}
+  {{ text }}
+  <slot/>
 </button>
 </template>
 
@@ -17,7 +18,6 @@ export default {
     },
     text: {
       type: String,
-      required: true,
     },
   },
   computed: {
@@ -40,6 +40,7 @@ export default {
   outline: none;
   height: 24px;
   line-height: 24px;
+  text-transform: uppercase;
 
   &:after {
     content: '';

--- a/src/Select.vue
+++ b/src/Select.vue
@@ -170,8 +170,6 @@ $hover-option-color: #deebfa;
 $primary-input-size: 16px;
 $secondary-input-size: 14px;
 
-$input-font-style: Lato;
-
 .select-field {
   background-color: $input-background-color;
   border-bottom: 1px solid #e5e5e5;
@@ -181,7 +179,6 @@ $input-font-style: Lato;
   display: inline-block;
   vertical-align: top;
   font-size: $primary-input-size;
-  font-style: $input-font-style;
   height: 56px;
   padding: 24px 0 0;
   position: relative;
@@ -285,7 +282,11 @@ $input-font-style: Lato;
   width: 100%;
 }
 .overlay {
-  background-image: linear-gradient(0deg, $input-background-color 0%, rgba($input-background-color, 0) 100%);
+  background-image: linear-gradient(
+    0deg,
+    $input-background-color 0%,
+    rgba($input-background-color, 0) 100%
+  );
   bottom: 0;
   pointer-events: none;
   height: 40px;

--- a/src/Select.vue
+++ b/src/Select.vue
@@ -1,7 +1,7 @@
 <template>
 <div
   v-clickaway="blur"
-  :class="inputClasses"
+  :class="selectClasses"
   @click="focused ? blur() : focus()"
 >
   <span
@@ -19,23 +19,27 @@
     {{ additionalInfo }}
   </span>
   <span class="selected">
-    {{ dropdownValue }}
+    {{ selectedLabel }}
   </span>
   <div class="box">
     <div class="options">
       <label
-        v-for="(option, index) in options"
-        :key="index"
-        :class="['option', option === dropdownValue ? '_current' : '']"
+        v-for="option in optionsView"
+        :key="option.value"
+        class="option"
+        :class="{
+          '_empty': !option.value,
+          '_current': option === option.value
+        }"
       >
-        {{ option }}
+        {{ option.label }}
         <input
-          v-model="dropdownValue"
+          v-model="selectValue"
           class="input"
-          name="dropdownValue"
+          name="selectValue"
           type="radio"
           :required="required"
-          :value="option"
+          :value="option.value"
           @input="emitChange"
         >
       </label>
@@ -47,6 +51,7 @@
 
 <script>
 import { directive as clickaway } from 'vue-clickaway';
+import { find } from 'lodash-es';
 
 export default {
   directives: {
@@ -68,6 +73,15 @@ export default {
     options: {
       default: () => [],
       type: Array,
+      validator(value) {
+        if (!value.length) {
+          return true;
+        }
+        if (value[0].label !== undefined && value[0].value !== undefined) {
+          return true;
+        }
+        return false;
+      },
     },
     required: {
       default: false,
@@ -75,32 +89,59 @@ export default {
     },
     value: {
       default: '',
+      type: [String, Number],
+    },
+    hasEmptyValue: {
+      default: false,
+      type: Boolean,
+    },
+    placeholder: {
+      default: 'Not selected',
       type: String,
     },
   },
   data() {
     return {
-      dropdownValue: this.value,
+      selectValue: this.value,
       focused: false,
     };
   },
   computed: {
     /**
-     * Classes for dropdown
+     * Classes for select
      * @return {Array<string>}
      */
-    inputClasses() {
+    selectClasses() {
       return [
-        'dropdown-field',
+        'select-field',
         this.focused ? '_focused' : '',
-        !this.dropdownValue ? '_empty' : '',
+        !this.selectValue ? '_empty' : '',
         this.disabled ? '_disabled' : '',
       ];
+    },
+
+    selectedLabel() {
+      const selectedItem = find(this.options, { value: this.selectValue });
+      return selectedItem ? selectedItem.label : this.placeholder;
+    },
+
+    optionsView() {
+      if (this.hasEmptyValue) {
+        return [
+          {
+            label: this.placeholder,
+            value: '',
+          },
+          ...this.options,
+        ];
+      }
+
+      return this.options;
     },
   },
   watch: {
     value(val) {
-      this.dropdownValue = val;
+      this.selectValue = val;
     },
   },
   methods: {
@@ -131,16 +172,14 @@ $secondary-input-size: 14px;
 
 $input-font-style: Lato;
 
-.dropdown-field {
+.select-field {
   background-color: $input-background-color;
-  border-style: solid;
-  border-width: 0;
-  border-bottom-width: 1px;
-  border-color: #e5e5e5;
+  border-bottom: 1px solid #e5e5e5;
   box-sizing: border-box;
   color: $primary-input-color;
   cursor: pointer;
   display: inline-block;
+  vertical-align: top;
   font-size: $primary-input-size;
   font-style: $input-font-style;
   height: 56px;
@@ -213,18 +252,22 @@ $input-font-style: Lato;
 }
 .selected {
   display: block;
-  width: 100px;
   height: 32px;
   line-height: 32px;
   transform: scaleY(0);
   transform-origin: bottom;
   transition: transform 0.2s ease-out;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: calc(100% - 12px);
 }
 .box {
   background-color: $input-background-color;
   box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.1);
   left: -16px;
   position: absolute;
+  z-index: 10;
   text-overflow: ellipsis;
   top: 56px;
   transform: scaleY(0);
@@ -262,6 +305,10 @@ $input-font-style: Lato;
   &:hover,
   &._current {
     background-color: $hover-option-color;
+  }
+
+  &._empty {
+    color: $secondary-input-color;
   }
 }
 input {

--- a/src/Select.vue
+++ b/src/Select.vue
@@ -180,7 +180,7 @@ $secondary-input-size: 14px;
   vertical-align: top;
   font-size: $primary-input-size;
   height: 56px;
-  padding: 24px 0 0;
+  padding: 24px 0;
   position: relative;
   transition: border-color 0.2s ease-out;
   width: 100%;

--- a/src/TextField.vue
+++ b/src/TextField.vue
@@ -114,7 +114,7 @@ $secondary-input-size: 14px;
 
 .text-field {
   display: inline-block;
-  padding: 24px 0 0;
+  padding: 24px 0;
   position: relative;
   width: 100%;
 }

--- a/src/TextField.vue
+++ b/src/TextField.vue
@@ -117,7 +117,7 @@ $input-font-style: Lato;
 .text-field {
   display: inline-block;
   font-style: $input-font-style;
-  padding: 24px 0;
+  padding: 24px 0 0;
   position: relative;
   width: 100%;
 }

--- a/src/TextField.vue
+++ b/src/TextField.vue
@@ -112,11 +112,8 @@ $error-input-color: #ff6f6f;
 $primary-input-size: 16px;
 $secondary-input-size: 14px;
 
-$input-font-style: Lato;
-
 .text-field {
   display: inline-block;
-  font-style: $input-font-style;
   padding: 24px 0 0;
   position: relative;
   width: 100%;


### PR DESCRIPTION
Основные моменты:
1. `Dropdown` переименован в `Select`
2. `Select` претерпел ряд корректировок. Основная - это список опций теперь принимается в виде коллекции (массив объектов `{label: '', value: ''}`
3. Добавил в кнопки слоты, чтобы можно было пихать контент слотом. Передача через `text` сохранена
4. У TextField убран нижний паддинг. Сделано для однородности с Select, чтобы они однородно отображались в одном списке