### PR TITLE
adds hover background and url handling for ui-table-row

### DIFF
--- a/src/UiTableRow.vue
+++ b/src/UiTableRow.vue
@@ -1,15 +1,17 @@
 <template>
-<div
+<component
+  :is="tagName"
   class="ui-table-row"
   :class="{
     '_head': isHead,
     '_hoverable': isHoverable,
-    '_clickable': url
+    '_clickable': link
   }"
-  @click="handleRowClick"
+  :to="link && link.router ? link.url : null"
+  :href="link ? link.url : null"
 >
   <slot />
-</div>
+</component>
 </template>
 
 <script>
@@ -25,16 +27,31 @@ export default {
       type: Boolean,
       default: true,
     },
-    url: {
-      type: String,
+    link: {
+      type: Object,
     },
   },
 
-  methods: {
-    handleRowClick() {
-      if (this.url) {
-        this.$router.push(this.url);
+  computed: {
+    routerComponentName() {
+      if (this.$options.components.NuxtLink) {
+        return 'NuxtLink';
       }
+      if (this.$options.components.RouterLink) {
+        return 'RouterLink';
+      }
+      return 'a';
+    },
+    tagName() {
+      if (!this.link) {
+        return 'div';
+      }
+
+      if (this.link && this.link.router) {
+        return this.routerComponentName;
+      }
+
+      return 'a';
     },
   },
 };
@@ -44,8 +61,9 @@ export default {
 <style lang="scss" scoped>
 .ui-table-row {
   display: table-row;
+  text-decoration: none;
 
-  &._clickable:hover {
+  &._hoverable:hover {
     background: #e3eeff;
   }
 

--- a/src/UiTableRow.vue
+++ b/src/UiTableRow.vue
@@ -1,7 +1,12 @@
 <template>
 <div
   class="ui-table-row"
-  :class="{'_head': isHead}"
+  :class="{
+    '_head': isHead,
+    '_hoverable': isHoverable,
+    '_clickable': url
+  }"
+  @click="handleRowClick"
 >
   <slot />
 </div>
@@ -16,6 +21,21 @@ export default {
       type: Boolean,
       default: false,
     },
+    isHoverable: {
+      type: Boolean,
+      default: true,
+    },
+    url: {
+      type: String,
+    },
+  },
+
+  methods: {
+    handleRowClick() {
+      if (this.url) {
+        this.$router.push(this.url);
+      }
+    },
   },
 };
 </script>
@@ -24,5 +44,13 @@ export default {
 <style lang="scss" scoped>
 .ui-table-row {
   display: table-row;
+
+  &._clickable:hover {
+    background: #e3eeff;
+  }
+
+  &._clickable {
+    cursor: pointer;
+  }
 }
 </style>


### PR DESCRIPTION
1. При ховере строчка таблицы теперь меняет цвет.
Не уверен, что это нужно прям везде, поэтому сделал опцию для отключения эффекта.
![hover-table](https://user-images.githubusercontent.com/8308691/53330200-f5e84780-38fe-11e9-9883-226f8b5cb982.png)


2. Добавил обработку урлов (переход по клику). Сделано с использованием компонента роутера, который компилится в физическую ссылку.
Использование выглядит так:
```
<ui-table-row
  v-for="project in projects"
  :key="project.id"
  :link="{
    url: `/project/${project.id}`,
    router: true
  }"
>
```
Сответственно, можно регулировать, навигационный это переход или нет через параметр `router`