### PR TITLE
adds new option indent with value 'shallow' for TagBox and TagInput

### DIFF
--- a/src/TagBox.vue
+++ b/src/TagBox.vue
@@ -1,5 +1,8 @@
 <template>
-<div class="tag-box">
+<div 
+  class="tag-box"
+  :class="[`_indent-${indent}`, {'_no-tags': !tags.length}]"
+>
   <span
     v-for="(tag, index) in tags"
     :key="index"
@@ -12,6 +15,8 @@
 </template>
 
 <script>
+import { includes } from 'lodash-es';
+
 export default {
   props: {
     /**
@@ -21,6 +26,14 @@ export default {
     tags: {
       default: () => [],
       type: Array,
+    },
+
+    indent: {
+      type: String,
+      default: 'default',
+      validator(value) {
+        return includes(['default', 'shallow'], value);
+      },
     },
   },
 
@@ -67,6 +80,14 @@ $tag-colors: (
   width: 100%;
   flex-wrap: wrap;
   padding: 8px 0;
+
+  &._indent-shallow {
+    padding-bottom: 0;
+
+    &._no-tags {
+      padding-top: 0;
+    }
+  }
 }
 .tag {
   position: relative;

--- a/src/TagInput.vue
+++ b/src/TagInput.vue
@@ -1,7 +1,11 @@
 <template>
-<div class="tag-input">
+<div
+  class="tag-input"
+  :class="`_indent-${indent}`"
+>
   <TagBox
     :tags="localSelectedTags"
+    :indent="indent"
     @removeTag="removeTag"
   />
   <div
@@ -54,6 +58,14 @@ export default {
     tags: {
       default: () => [],
       type: Array,
+    },
+
+    indent: {
+      type: String,
+      default: 'default',
+      validator(value) {
+        return includes(['default', 'shallow'], value);
+      },
     },
   },
   data() {
@@ -119,6 +131,10 @@ export default {
 .tag-input {
   padding: 24px 0;
   width: 100%;
+
+  &._indent-shallow {
+    padding: 0;
+  }
 }
 .field {
   max-width: 320px;

--- a/src/TagInput.vue
+++ b/src/TagInput.vue
@@ -38,6 +38,10 @@ export default {
     clickaway,
   },
   components: { TagBox, TagList, TextField },
+  model: {
+    prop: 'selectedTags',
+    event: 'change',
+  },
   props: {
     label: {
       default: 'List of tags',


### PR DESCRIPTION
Добавил опцию TagInput для радикального сокращения отступов, чтобы можно было соблюсти сетку.
А ЕЩЁ научил TagInput юзать v-model
С `indent="shallow"` теперь так:

не заполнено
![tag-input](https://user-images.githubusercontent.com/8308691/53716541-57139c00-3e66-11e9-9fa8-ad345842c95d.png)
заполнено
![tag-input2](https://user-images.githubusercontent.com/8308691/53716544-58dd5f80-3e66-11e9-89d0-168ca7f1295a.png)
