### PR TITLE
Add possible for sort in table head

### DIFF
--- a/src/UiTableCell.vue
+++ b/src/UiTableCell.vue
@@ -1,10 +1,10 @@
 <template>
 <div
   class="ui-table-cell"
-  :class="{'_head': isHead, ['_' + sortDirection]: isSortAvailable}"
+  :class="{'_head': isHead, '_is-sortable': isSortAvailable, ['_' + sortDirection]: sortDirection}"
 >
   <svg
-    v-if="isSortAvailable"
+    v-if="isSortAvailable && sortDirection"
     class="sort-arrow"
     width="8"
     height="10"
@@ -17,6 +17,8 @@
 </template>
 
 <script>
+import { includes } from 'lodash-es';
+
 export default {
   name: 'UiTableRow',
 
@@ -26,8 +28,11 @@ export default {
       type: Boolean,
     },
     sortDirection: {
-      default: 'desc',
+      default: null,
       type: String,
+      validator(value) {
+        return includes(['asc', 'desc', null], value);
+      },
     },
   },
   data() {
@@ -61,8 +66,7 @@ export default {
     background: #f6f6f6;
     color: #b1b1b1;
 
-    &._asc,
-    &._desc {
+    &._is-sortable {
       color: #0c2441;
       cursor: pointer;
     }
@@ -76,5 +80,6 @@ export default {
 }
 .sort-arrow {
   fill: #b1b1b1;
+  vertical-align: baseline;
 }
 </style>

--- a/src/UiTableCell.vue
+++ b/src/UiTableCell.vue
@@ -1,8 +1,17 @@
 <template>
 <div
   class="ui-table-cell"
-  :class="{'_head': isHead}"
+  :class="{'_head': isHead, ['_' + sortDirection]: isSortAvailable}"
 >
+  <svg
+    v-if="isSortAvailable"
+    class="sort-arrow"
+    width="8"
+    height="10"
+    viewBox="0 0 8 10"
+  >
+    <path d="M3.64645 9.35355C3.84171 9.54882 4.15829 9.54882 4.35355 9.35355L7.53553 6.17157C7.7308 5.97631 7.7308 5.65973 7.53553 5.46447C7.34027 5.2692 7.02369 5.2692 6.82843 5.46447L4 8.29289L1.17157 5.46447C0.976311 5.2692 0.659728 5.2692 0.464466 5.46447C0.269204 5.65973 0.269204 5.97631 0.464466 6.17157L3.64645 9.35355ZM3.5 0L3.5 9H4.5L4.5 0L3.5 0Z"/>
+  </svg>
   <slot />
 </div>
 </template>
@@ -11,10 +20,25 @@
 export default {
   name: 'UiTableRow',
 
+  props: {
+    isSortable: {
+      default: false,
+      type: Boolean,
+    },
+    sortDirection: {
+      default: 'desc',
+      type: String,
+    },
+  },
   data() {
     return {
       isHead: this.$parent.isHead || false,
     };
+  },
+  computed: {
+    isSortAvailable() {
+      return this.isHead && this.isSortable;
+    },
   },
 };
 </script>
@@ -36,6 +60,21 @@ export default {
     padding-bottom: 10px;
     background: #f6f6f6;
     color: #b1b1b1;
+
+    &._asc,
+    &._desc {
+      color: #0c2441;
+      cursor: pointer;
+    }
+
+    &._asc {
+      & > .sort-arrow {
+        transform: rotate(180deg);
+      }
+    }
   }
+}
+.sort-arrow {
+  fill: #b1b1b1;
 }
 </style>


### PR DESCRIPTION
Добавляем стрелочку сортировки для заголовков таблицы:
![image](https://user-images.githubusercontent.com/13607402/54738040-185f3f00-4be5-11e9-8809-308722b04ea1.png)

![image](https://user-images.githubusercontent.com/13607402/54738052-2b720f00-4be5-11e9-881e-b455524be5bd.png)

При помощи пропсы isSortable определяем, сортируется ли таблица по этому полю вообще (то есть если сортируется, то меняются стили, добавляется кликабельность и меняется цвет текста).
Пропса sortDirection отвечает за направление сортировки и может иметь три значения: 'asc', 'desc' и null. При значении null стрелочка отсутствует, но возможность нажать и следовательно добавить сортировку по этому полю можно. Для этого и потребовалось две пропсы)