### PR TITLE
Add background transparent for UiButton

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.0] - 2019-03-21
+- Add background transparent for UiButton
+
 ## [1.19.0] - 2019-03-21
 - Add errorMessages for UiSelect
 - Fix TextField empty view with number zero value

--- a/src/Button.vue
+++ b/src/Button.vue
@@ -25,6 +25,10 @@ export default {
       default: false,
       type: Boolean,
     },
+    isTransparent: {
+      default: false,
+      type: Boolean,
+    },
     size: {
       default: 'default',
       type: String,
@@ -57,6 +61,7 @@ export default {
          */
         'base-button',
         this.disabled ? '_disabled' : '',
+        this.isTransparent ? '_transparent' : '',
         ...[this.color, this.size, this.type].map(value => `_${value}`),
       ];
     },
@@ -148,6 +153,12 @@ $button-font-style: Loto;
 
   &._rectangle {
     border-radius: 4px;
+  }
+
+  &._transparent {
+    background-color: transparent;
+    color: $background;
+    box-shadow: inset 0px 0px 0px 2px rgba($background, 0.6);
   }
 }
 


### PR DESCRIPTION
Default:
![image](https://user-images.githubusercontent.com/13607402/54743229-25385e80-4bf6-11e9-933d-8f8804a26918.png)

Hover:
![image](https://user-images.githubusercontent.com/13607402/54743279-439e5a00-4bf6-11e9-9550-f94206573680.png)

Так как цвет текста кнопки и цвет бордера зависят от того цвета, который мы передаем, пришлось сделать для transparent отдельную пропсу.