### PR TITLE
removes text-decoration from link inside PageHeader

### DIFF
--- a/src/PageHeader.vue
+++ b/src/PageHeader.vue
@@ -156,6 +156,7 @@ export default {
 
   a {
     color: inherit;
+    text-decoration: none;
   }
 }
 


### PR DESCRIPTION
У меня раньше тоже по-дефолту для ссылок было убрано подчёркивание, а тут отрубил стили бутстрапа...
В общем, вроде лишним не будет )