### PR TITLE
adds text field of TagInput clearing on blur

### DIFF
--- a/src/TagInput.vue
+++ b/src/TagInput.vue
@@ -13,9 +13,11 @@
     :class="['field', fieldFocused ? '_focused' : '']"
   >
     <TextField
+      v-model="textFieldValue"
       :label="label"
       @input="search"
       @focus="focus"
+      @blur="textFieldValue = ''"
     />
     <TagList
       class="list-tag"
@@ -77,6 +79,7 @@ export default {
       localTags: this.tags,
       localSelectedTags: this.selectedTags,
       fieldFocused: false,
+      textFieldValue: '',
     };
   },
   computed: {


### PR DESCRIPTION
Зачищаем тектовое поле на блюре. Вроде ничему не мешает, т.к. оно используется только для поиска значений.
Нужно, т.к. пустое поле выглядит как обычный инпут, при этом значение внутри инпута не подчинается никаким зачищениям, в итоге при спользовании в качестве поискового фильтра поле выглядит как заполненный инпут, который не очищается
![tag-input-blur](https://user-images.githubusercontent.com/8308691/57609984-9d792b80-7578-11e9-88d8-e82efb484d37.gif)
